### PR TITLE
Add a graceful exit for the interactive dev session

### DIFF
--- a/session_config.sh
+++ b/session_config.sh
@@ -4,13 +4,13 @@
 ######################################
 
 # Variables for SSH and remote execution
-REMOTE_USER="your_watcloud_username"    # Your WATcloud Username
-REMOTE_HOST="watcloud_remote_host"      # [tr-ubuntu3, derek3-ubuntu2]
-SSH_KEY="path_to_private_key"           # Path to your local private key
+export REMOTE_USER="your_watcloud_username"    # Your WATcloud Username
+export REMOTE_HOST="watcloud_remote_host"      # [tr-ubuntu3, derek3-ubuntu2]
+export SSH_KEY="path_to_private_key"           # Path to your local private key
 
 # SLURM job configuration
-NUMER_OF_CPUS=4         # Number of CPUs to use
-MEMORY=16G              # Amount of RAM to use
-USAGE_TIME="6:00:00"    # How long you want to run the session for
-TMP_DISK_SIZE=10240     # How much temporary storage you want [in MiB]
-VRAM=0                  # How much GPU VRAM you want [in MiB]
+export NUMBER_OF_CPUS=4         # Number of CPUs to use
+export MEMORY=16G              # Amount of RAM to use
+export USAGE_TIME="6:00:00"    # How long you want to run the session for
+export TMP_DISK_SIZE=10240     # How much temporary storage you want [in MiB]
+export VRAM=0                  # How much GPU VRAM you want [in MiB]

--- a/session_config.sh
+++ b/session_config.sh
@@ -4,13 +4,13 @@
 ######################################
 
 # Variables for SSH and remote execution
-export REMOTE_USER="j257jian"    # Your WATcloud Username
-export REMOTE_HOST="tr-ubuntu3"      # [tr-ubuntu3, derek3-ubuntu2]
-export SSH_KEY="~/.ssh/WATO_rsa"           # Path to your local private key
+REMOTE_USER="your_watcloud_username"    # Your WATcloud Username
+REMOTE_HOST="watcloud_remote_host"      # [tr-ubuntu3, derek3-ubuntu2]
+SSH_KEY="path_to_private_key"           # Path to your local private key
 
 # SLURM job configuration
-export NUMBER_OF_CPUS=4         # Number of CPUs to use
-export MEMORY=16G              # Amount of RAM to use
-export USAGE_TIME="6:00:00"    # How long you want to run the session for
-export TMP_DISK_SIZE=40960     # How much temporary storage you want [in MiB]
-export VRAM=0                  # How much GPU VRAM you want [in MiB]
+NUMER_OF_CPUS=4         # Number of CPUs to use
+MEMORY=16G              # Amount of RAM to use
+USAGE_TIME="6:00:00"    # How long you want to run the session for
+TMP_DISK_SIZE=10240     # How much temporary storage you want [in MiB]
+VRAM=0                  # How much GPU VRAM you want [in MiB]

--- a/session_config.sh
+++ b/session_config.sh
@@ -4,13 +4,13 @@
 ######################################
 
 # Variables for SSH and remote execution
-REMOTE_USER="your_watcloud_username"    # Your WATcloud Username
-REMOTE_HOST="watcloud_remote_host"      # [tr-ubuntu3, derek3-ubuntu2]
-SSH_KEY="path_to_private_key"           # Path to your local private key
+export REMOTE_USER="j257jian"    # Your WATcloud Username
+export REMOTE_HOST="tr-ubuntu3"      # [tr-ubuntu3, derek3-ubuntu2]
+export SSH_KEY="~/.ssh/WATO_rsa"           # Path to your local private key
 
 # SLURM job configuration
-NUMER_OF_CPUS=4         # Number of CPUs to use
-MEMORY=16G              # Amount of RAM to use
-USAGE_TIME="6:00:00"    # How long you want to run the session for
-TMP_DISK_SIZE=10240     # How much temporary storage you want [in MiB]
-VRAM=0                  # How much GPU VRAM you want [in MiB]
+export NUMBER_OF_CPUS=4         # Number of CPUs to use
+export MEMORY=16G              # Amount of RAM to use
+export USAGE_TIME="6:00:00"    # How long you want to run the session for
+export TMP_DISK_SIZE=40960     # How much temporary storage you want [in MiB]
+export VRAM=0                  # How much GPU VRAM you want [in MiB]

--- a/slurm_job_templates/asd_interactive_job.slurm
+++ b/slurm_job_templates/asd_interactive_job.slurm
@@ -5,12 +5,18 @@ if [ -z "${SLURM_JOB_ID:-}" ]; then
     exit 1
 fi
 
-cleanup() {
-  echo "Ctrl+C detected. Exiting gracefully..."
-  
-  # if 2 cleanups, exit right away
+SIGINT_COUNT=0
 
-  exit 0
+cleanup() {
+    SIGINT_COUNT=$((SIGINT_COUNT + 1))
+    echo "Ctrl+C detected. Exiting gracefully... ()"
+
+    if [ "$SIGINT_COUNT" -gt 1 ]; then
+        echo "Second Ctrl+C detected. Exiting forcefully."
+        exit 1  
+    fi
+    
+    exit 0
 }
 
 trap cleanup SIGINT

--- a/slurm_job_templates/asd_interactive_job.slurm
+++ b/slurm_job_templates/asd_interactive_job.slurm
@@ -9,7 +9,7 @@ SIGINT_COUNT=0
 
 cleanup() {
     SIGINT_COUNT=$((SIGINT_COUNT + 1))
-    echo "Ctrl+C detected. Exiting gracefully... ()"
+    echo "Ctrl+C detected. Exiting gracefully...(press Ctrl+C again to force)"
 
     if [ "$SIGINT_COUNT" -gt 1 ]; then
         echo "Second Ctrl+C detected. Exiting forcefully."

--- a/slurm_job_templates/asd_interactive_job.slurm
+++ b/slurm_job_templates/asd_interactive_job.slurm
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+cleanup() {
+  echo "Ctrl+C detected. Exiting gracefully..."
+  exit 0
+}
+
+trap cleanup SIGINT
+
 # Load docker session if exists, create file in wato-drive2 otherwise
 DOCKER_SESSION_DIR="/mnt/wato-drive2/slurm-docker-sessions/$(id -u)/"
 DOCKER_STATE_FILE="slurm-docker-state.tar.zst"

--- a/slurm_job_templates/asd_interactive_job.slurm
+++ b/slurm_job_templates/asd_interactive_job.slurm
@@ -1,7 +1,15 @@
 #!/bin/bash
 
+if [ -z "${SLURM_JOB_ID:-}" ]; then
+    1>&2 echo "This script is meant to be run from within a Slurm job. We are not in a Slurm job. Exiting..."
+    exit 1
+fi
+
 cleanup() {
   echo "Ctrl+C detected. Exiting gracefully..."
+  
+  # if 2 cleanups, exit right away
+
   exit 0
 }
 

--- a/slurm_job_templates/srun_interactive_job.sh
+++ b/slurm_job_templates/srun_interactive_job.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-sed -i 's/\r$//' $REMOTE_SLURM_FILE
-
-# Run srun command
-/opt/slurm/bin/srun --cpus-per-task=$NUMER_OF_CPUS --mem=$MEMORY \\
-    --gres=tmpdisk:$TMP_DISK_SIZE,shard=$VRAM --time=$USAGE_TIME --job-name=wato_slurm_dev \\
-    --pty bash ~/slurm_tooling/asd_interactive_job.slurm

--- a/slurm_job_templates/srun_interactive_job.sh
+++ b/slurm_job_templates/srun_interactive_job.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+sed -i 's/\r$//' $REMOTE_SLURM_FILE
+
+# Run srun command
+/opt/slurm/bin/srun --cpus-per-task=$NUMER_OF_CPUS --mem=$MEMORY \\
+    --gres=tmpdisk:$TMP_DISK_SIZE,shard=$VRAM --time=$USAGE_TIME --job-name=wato_slurm_dev \\
+    --pty bash ~/slurm_tooling/asd_interactive_job.slurm

--- a/slurm_job_templates/srun_interactive_job_template.sh
+++ b/slurm_job_templates/srun_interactive_job_template.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+sed -i 's/\r$//' $REMOTE_SLURM_JOB_SCRIPT
+
+# Run srun command
+/opt/slurm/bin/srun --cpus-per-task=${NUMBER_OF_CPUS} --mem=${MEMORY} \
+    --gres=tmpdisk:${TMP_DISK_SIZE},shard=${VRAM} --time=${USAGE_TIME} --job-name=wato_slurm_dev \
+    --pty bash ~/slurm_tooling/asd_interactive_job.slurm

--- a/start_interactive_session.sh
+++ b/start_interactive_session.sh
@@ -3,9 +3,13 @@
 SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 source "$SCRIPT_DIR/session_config.sh"
 
-REMOTE_SLURM_DIR="~/slurm_tooling"
-REMOTE_SLURM_FILE="$REMOTE_SLURM_DIR/asd_interactive_job.slurm"
-LOCAL_SLURM_FILE="$SCRIPT_DIR/slurm_job_templates/asd_interactive_job.slurm"
+UPDATE_WATO_ASD_TOOLING=${UPDATE_WATO_ASD_TOOLING:-""}
+
+export REMOTE_SLURM_DIR="~/slurm_tooling"
+export REMOTE_SLURM_JOB_SCRIPT="$REMOTE_SLURM_DIR/asd_interactive_job.slurm"
+export LOCAL_SLURM_JOB_SCRIPT="$SCRIPT_DIR/slurm_job_templates/asd_interactive_job.slurm"
+export REMOTE_JOB_LAUNCH_SCRIPT="$REMOTE_SLURM_DIR/srun_interactive_job.sh"
+export LOCAL_JOB_LAUNCH_TEMPLATE="$SCRIPT_DIR/slurm_job_templates/srun_interactive_job_template.sh"
 
 # Check if the slurm_tooling directory exists and create it if necessary, and check if the file exists
 ssh -i $SSH_KEY $REMOTE_USER@$REMOTE_HOST << EOF
@@ -17,33 +21,26 @@ else
     echo "Directory $REMOTE_SLURM_DIR already exists."
 fi
 
-if [ ! -f $REMOTE_SLURM_FILE ]; then
-    echo "File does not exist on the remote machine. Ready to copy from local."
-    exit 1  # File not found
+if [ ! -f $REMOTE_SLURM_JOB_SCRIPT ] || [ ! -f $REMOTE_JOB_LAUNCH_SCRIPT ]; then
+    echo "Required files do not exist on the remote machine. Ready to copy from local."
+    exit 1  # File(s) not found
 else
-    echo "File already exists on the remote machine."
-    exit 0  # File exists
+    echo "Files already exist on the remote machine."
+    exit 0  # Required files exist
 fi
 EOF
 
 # Check the exit status of the previous command
-if [ $? -eq 1  || UPDATE_REMOTE_FILES ]; then
+# UPDATE_WATO_ASD_TOOLING is an optionally set env var to be exported by the user
+if [ $? -eq 1 ] || [ -n "$UPDATE_WATO_ASD_TOOLING" ]; then
     echo "Copying asd_interactive_job.slurm to the remote machine..."
-    scp -i $SSH_KEY $LOCAL_SLURM_FILE $REMOTE_USER@$REMOTE_HOST:~/slurm_tooling/
-    echo "coping the other thing too"
-    scp -i THING
+    scp -p -i "$SSH_KEY" "$LOCAL_SLURM_JOB_SCRIPT" "$REMOTE_USER@$REMOTE_HOST:~/slurm_tooling/"
+    
+    echo "Copying the launch script to the remote machine..."
+    TMP_JOB_LAUNCH_SCRIPT=$(mktemp)
+    chmod +x "$TMP_JOB_LAUNCH_SCRIPT"
+    envsubst < "$LOCAL_JOB_LAUNCH_TEMPLATE" > "$TMP_JOB_LAUNCH_SCRIPT"
+    scp -p -i "$SSH_KEY" "$TMP_JOB_LAUNCH_SCRIPT" "$REMOTE_USER@$REMOTE_HOST:$REMOTE_JOB_LAUNCH_SCRIPT"
 fi
 
-# SSH command to run remote script
-ssh -t -i "$SSH_KEY" "$REMOTE_USER@$REMOTE_HOST" << EOF
-#!/bin/bash
-
-sed -i 's/\r$//' $REMOTE_SLURM_FILE
-
-# Run srun command
-srun --cpus-per-task=$NUMER_OF_CPUS --mem=$MEMORY \\
-    --gres=tmpdisk:$TMP_DISK_SIZE,shard=$VRAM --time=$USAGE_TIME --job-name=wato_slurm_dev \\
-    --pty bash ~/slurm_tooling/asd_interactive_job.slurm
-EOF
-
-# ssh -t HOST "~/some_script.sh"
+ssh -t -i "$SSH_KEY" "$REMOTE_USER@$REMOTE_HOST" "$REMOTE_JOB_LAUNCH_SCRIPT"

--- a/start_interactive_session.sh
+++ b/start_interactive_session.sh
@@ -27,13 +27,15 @@ fi
 EOF
 
 # Check the exit status of the previous command
-if [ $? -eq 1 ]; then
+if [ $? -eq 1  || UPDATE_REMOTE_FILES ]; then
     echo "Copying asd_interactive_job.slurm to the remote machine..."
     scp -i $SSH_KEY $LOCAL_SLURM_FILE $REMOTE_USER@$REMOTE_HOST:~/slurm_tooling/
+    echo "coping the other thing too"
+    scp -i THING
 fi
 
 # SSH command to run remote script
-ssh -tt -i "$SSH_KEY" "$REMOTE_USER@$REMOTE_HOST" << EOF
+ssh -t -i "$SSH_KEY" "$REMOTE_USER@$REMOTE_HOST" << EOF
 #!/bin/bash
 
 sed -i 's/\r$//' $REMOTE_SLURM_FILE
@@ -44,4 +46,4 @@ srun --cpus-per-task=$NUMER_OF_CPUS --mem=$MEMORY \\
     --pty bash ~/slurm_tooling/asd_interactive_job.slurm
 EOF
 
-ssh -t HOST ~/some_script.sh
+# ssh -t HOST "~/some_script.sh"

--- a/start_interactive_session.sh
+++ b/start_interactive_session.sh
@@ -43,3 +43,5 @@ srun --cpus-per-task=$NUMER_OF_CPUS --mem=$MEMORY \\
     --gres=tmpdisk:$TMP_DISK_SIZE,shard=$VRAM --time=$USAGE_TIME --job-name=wato_slurm_dev \\
     --pty bash ~/slurm_tooling/asd_interactive_job.slurm
 EOF
+
+ssh -t HOST ~/some_script.sh


### PR DESCRIPTION
would look something like:

```
Jimmys-MacBook-Pro:wato_asd_tooling Jimmy$ ./start_interactive_session.sh 
Saved docker state found. Loading...
18.2GiB 0:00:43 [ 430MiB/s] [                                                                                     <=>            ]
[NOTICE] SLURM JOB STARTING WITH JOB_ID 12184. To connect to it through the terminal, use:

srun --pty --overlap --jobid 12184 bash

Starting dockerd. Data root: '/tmp/docker'. Log file: '/tmp/dockerd.log'
Waiting for dockerd to start...
^CCtrl+C detected. Exiting gracefully...
Connection to tr-ubuntu3.cluster.watonomous.ca closed.
```